### PR TITLE
handle missing context property

### DIFF
--- a/__tests__/parameters.test.ts
+++ b/__tests__/parameters.test.ts
@@ -2,9 +2,55 @@ import { describe, expect, test } from 'vitest';
 import { parseImageServiceRequest } from '../src/utility/parse-image-service-request';
 import { imageServiceRequestToString } from '../src/utility/image-service-request-to-string';
 import { createImageServiceRequest } from '../src/utility/create-image-service-request';
+import { ImageServiceImageRequest } from '../src';
+import { ImageService } from '@iiif/presentation-3';
 
 describe('IIIF Image API Parameters', () => {
   /// {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}
+
+  describe('SI JPCA image service examples', () => {
+    test('image service without explicit context', () => {
+      const parsed = {
+        scheme: 'https',
+        server: 'iiif.jpcarchive.org',
+        prefix: '',
+        identifier: 'iiif/v2.0/media/JPC-b0a2d4ca692a34ef465ff5b5c736391d_0009_001',
+        originalPath: '',
+        type: 'image',
+        region: {
+          full: true,
+        },
+        size: {
+          max: false,
+          upscaled: false,
+          confined: false,
+          width: 550,
+          height: 600,
+        },
+        rotation: {
+          angle: 0,
+          mirror: false,
+        },
+        format: 'jpg',
+        quality: 'default',
+      } as ImageServiceImageRequest;
+
+      const service = {
+        sizes: [],
+        width: 550,
+        height: 600,
+        maxWidth: 550,
+        maxHeight: 600,
+        id: 'https://iiif.jpcarchive.org/iiif/v2.0/media/JPC-b0a2d4ca692a34ef465ff5b5c736391d_0009_001',
+        type: 'ImageService2',
+        profile: 'level2',
+      } as ImageService;
+
+      expect(imageServiceRequestToString(parsed, service)).toEqual(
+        'https://iiif.jpcarchive.org/iiif/v2.0/media/JPC-b0a2d4ca692a34ef465ff5b5c736391d_0009_001/full/full/0/default.jpg'
+      );
+    });
+  });
 
   describe('munch.emuseum.com examples', () => {
     // https://munch.emuseum.com/apis/iiif/image/v2/17261/full/max/0/default.jpg

--- a/src/utility/image-service-request-to-string.ts
+++ b/src/utility/image-service-request-to-string.ts
@@ -26,7 +26,9 @@ export function imageServiceRequestToString(req: ImageServiceImageRequest, servi
         ? service['@context']
         : [service['@context']]
       : [];
-    const is2 = ctx.indexOf('http://iiif.io/api/image/2/context.json') !== -1;
+    const profile = service['profile'];
+    // fallback for bug where some level 2 image services lack a context
+    const is2 = ctx.indexOf('http://iiif.io/api/image/2/context.json') !== -1 || profile === 'level2';
     const is3 = ctx.indexOf('http://iiif.io/api/image/3/context.json') !== -1;
 
     // max size, for canonical.


### PR DESCRIPTION
@stephenwf I somewhat recall that this library is likely to be replaced in CanvasPanel by another soon, however we've come across an odd bug with images from the SI image service recently that led to me here.

As a preface, we are now handling many images from the Smithsonian that are quite small in size and that pose an issue with the `skipSizes` logic that we had previously implemented, as the result is often to load a size that is smaller than the viewer component itself. 

When we disabled that logic, we encountered a secondary issue where it seems like the initial image service property that is being returned is without a `@context` property, and as a result the subsequent image request for the initial full image defaults to the v3 `max` syntax and isn't fulfilled. 

The source of the missing `@context` is still a little unclear to me, you can see it in Storybook [here](https://661e9a3e73878cbdb2883fe6-henkexuonk.chromatic.com/?path=/story/web-components-exposed-canvas-panel-features--skip-sizes-false). It's worth noting that a secondary request is ultimately made that has the property set correctly, and that this is also only an issue when initially loading the image into the viewer, not for example if one was to load the viewer with another manifest/canvas, and then update the manifestUrl. This leads me to think it may be Vault-related in some way.

In any case, will continue to look into it further and curious if you have any thoughts on where to focus, but in the meantime in the interest of ensuring these images can be loaded correctly I've added this small fallback to look to the service's `profile` property when determining which syntax to use.